### PR TITLE
feat: expose dust attack detection, address scan and transaction simu…

### DIFF
--- a/src/main/java/io/gopluslabs/client/GoPlusClient.java
+++ b/src/main/java/io/gopluslabs/client/GoPlusClient.java
@@ -314,6 +314,83 @@ public class GoPlusClient {
     }
 
 
+    /**
+     * Check if the transfer between two addresses is a dust attack
+     *
+     * @param request DustAttackDetectionRequest
+     * @return DustAttackDetection
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public static DustAttackDetection dustAttackDetection(DustAttackDetectionRequest request) throws ApiException {
+        PublicControllerApi api = new PublicControllerApi();
+        api.setApiClient(createApiClient(request.getTimeout()));
+        ResponseWrapperDustAttackDetection response = api.dustAttackDetectionUsingPOST(
+                request.getBody(),
+                request.getAuthorization()
+        );
+        return DustAttackDetection.of(response);
+    }
+
+
+    /**
+     * Start an address security scan, the returned request_id is used by {@link #addressScanResult}
+     *
+     * @param request AddressScanRequest
+     * @return AddressScan
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public static AddressScan addressScan(AddressScanRequest request) throws ApiException {
+        SecWareOpenControllerApi api = new SecWareOpenControllerApi();
+        api.setApiClient(createApiClient(request.getTimeout()));
+        ResponseWrapperOpenScanAddressResp response = api.scanAddressUsingGET(
+                request.getAddress(),
+                request.getChainId(),
+                request.getAuthorization()
+        );
+        return AddressScan.of(response);
+    }
+
+
+    /**
+     * Get the result of an address security scan started by {@link #addressScan}
+     *
+     * @param request AddressScanResultRequest
+     * @return AddressScanResult
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public static AddressScanResult addressScanResult(AddressScanResultRequest request) throws ApiException {
+        SecWareOpenControllerApi api = new SecWareOpenControllerApi();
+        api.setApiClient(createApiClient(request.getTimeout()));
+        ResponseWrapperGetScanResult response = api.getScanResultUsingGET(
+                request.getRequestId(),
+                request.getAuthorization()
+        );
+        return AddressScanResult.of(response);
+    }
+
+
+    /**
+     * Get transaction security and risk data by simulating the transaction
+     *
+     * <p><b>Note:</b> this API expects a hexadecimal chain id (e.g. {@code "0x1"} for Ethereum mainnet,
+     * {@code "0x38"} for BSC), unlike {@link #tokenSecurity}, {@link #addressSecurity} and the other
+     * APIs, which take the decimal form ({@code "1"}, {@code "56"}).
+     *
+     * @param request TransactionSimulationRequest, whose chainId must be hexadecimal (e.g. {@code "0x1"})
+     * @return TransactionSimulation
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     */
+    public static TransactionSimulation transactionSimulation(TransactionSimulationRequest request) throws ApiException {
+        TransactionSecurityControllerApi api = new TransactionSecurityControllerApi();
+        api.setApiClient(createApiClient(request.getTimeout()));
+        ResponseWrapperTransactionSecurityResponse response = api.getTransactionSecurityInfoUsingPOST(
+                request.getBody(),
+                request.getAuthorization()
+        );
+        return TransactionSimulation.of(response);
+    }
+
+
     private static ApiClient createApiClient(Integer timeOut) {
         ApiClient apiClient = new ApiClient();
         OkHttpClient httpClient = apiClient.getHttpClient();

--- a/src/main/java/io/gopluslabs/client/request/AddressScanRequest.java
+++ b/src/main/java/io/gopluslabs/client/request/AddressScanRequest.java
@@ -1,0 +1,47 @@
+package io.gopluslabs.client.request;
+
+public class AddressScanRequest extends BaseRequest {
+
+    private String address;
+    private String chainId;
+
+    public static AddressScanRequest of(String address, String chainId) {
+        AddressScanRequest request = new AddressScanRequest();
+        request.address = address;
+        request.chainId = chainId;
+        return request;
+    }
+
+    public static AddressScanRequest of(String address, String chainId, String authorization) {
+        AddressScanRequest request = new AddressScanRequest();
+        request.address = address;
+        request.chainId = chainId;
+        request.authorization = authorization;
+        return request;
+    }
+
+    public static AddressScanRequest of(String address, String chainId, Integer timeout) {
+        AddressScanRequest request = new AddressScanRequest();
+        request.address = address;
+        request.chainId = chainId;
+        request.timeout = timeout;
+        return request;
+    }
+
+    public static AddressScanRequest of(String address, String chainId, String authorization, Integer timeout) {
+        AddressScanRequest request = new AddressScanRequest();
+        request.address = address;
+        request.chainId = chainId;
+        request.authorization = authorization;
+        request.timeout = timeout;
+        return request;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getChainId() {
+        return chainId;
+    }
+}

--- a/src/main/java/io/gopluslabs/client/request/AddressScanResultRequest.java
+++ b/src/main/java/io/gopluslabs/client/request/AddressScanResultRequest.java
@@ -1,0 +1,38 @@
+package io.gopluslabs.client.request;
+
+public class AddressScanResultRequest extends BaseRequest {
+
+    private String requestId;
+
+    public static AddressScanResultRequest of(String requestId) {
+        AddressScanResultRequest request = new AddressScanResultRequest();
+        request.requestId = requestId;
+        return request;
+    }
+
+    public static AddressScanResultRequest of(String requestId, String authorization) {
+        AddressScanResultRequest request = new AddressScanResultRequest();
+        request.requestId = requestId;
+        request.authorization = authorization;
+        return request;
+    }
+
+    public static AddressScanResultRequest of(String requestId, Integer timeout) {
+        AddressScanResultRequest request = new AddressScanResultRequest();
+        request.requestId = requestId;
+        request.timeout = timeout;
+        return request;
+    }
+
+    public static AddressScanResultRequest of(String requestId, String authorization, Integer timeout) {
+        AddressScanResultRequest request = new AddressScanResultRequest();
+        request.requestId = requestId;
+        request.authorization = authorization;
+        request.timeout = timeout;
+        return request;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+}

--- a/src/main/java/io/gopluslabs/client/request/DustAttackDetectionRequest.java
+++ b/src/main/java/io/gopluslabs/client/request/DustAttackDetectionRequest.java
@@ -1,0 +1,66 @@
+package io.gopluslabs.client.request;
+
+import io.gopluslabs.client.model.DustAttackDetectionReq;
+
+public class DustAttackDetectionRequest extends BaseRequest {
+
+    private String from;
+    private String to;
+
+    private DustAttackDetectionReq body;
+
+    public static DustAttackDetectionRequest of(String from, String to) {
+        DustAttackDetectionRequest request = new DustAttackDetectionRequest();
+        request.from = from;
+        request.to = to;
+        request.body = buildBody(from, to);
+        return request;
+    }
+
+    public static DustAttackDetectionRequest of(String from, String to, String authorization) {
+        DustAttackDetectionRequest request = new DustAttackDetectionRequest();
+        request.from = from;
+        request.to = to;
+        request.body = buildBody(from, to);
+        request.authorization = authorization;
+        return request;
+    }
+
+    public static DustAttackDetectionRequest of(String from, String to, Integer timeout) {
+        DustAttackDetectionRequest request = new DustAttackDetectionRequest();
+        request.from = from;
+        request.to = to;
+        request.body = buildBody(from, to);
+        request.timeout = timeout;
+        return request;
+    }
+
+    public static DustAttackDetectionRequest of(String from, String to, String authorization, Integer timeout) {
+        DustAttackDetectionRequest request = new DustAttackDetectionRequest();
+        request.from = from;
+        request.to = to;
+        request.body = buildBody(from, to);
+        request.authorization = authorization;
+        request.timeout = timeout;
+        return request;
+    }
+
+    private static DustAttackDetectionReq buildBody(String from, String to) {
+        DustAttackDetectionReq req = new DustAttackDetectionReq();
+        req.setFrom(from);
+        req.setTo(to);
+        return req;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public DustAttackDetectionReq getBody() {
+        return body;
+    }
+}

--- a/src/main/java/io/gopluslabs/client/request/TransactionSimulationRequest.java
+++ b/src/main/java/io/gopluslabs/client/request/TransactionSimulationRequest.java
@@ -1,0 +1,128 @@
+package io.gopluslabs.client.request;
+
+import io.gopluslabs.client.model.TransactionSecurityRequest;
+
+/**
+ * Request of {@code POST /api/v1/transaction_simulation}.
+ *
+ * <p><b>Note:</b> this API expects a hexadecimal chain id (e.g. {@code "0x1"} for Ethereum mainnet,
+ * {@code "0x38"} for BSC), unlike the other GoPlus APIs, which take the decimal form
+ * ({@code "1"}, {@code "56"}).
+ */
+public class TransactionSimulationRequest extends BaseRequest {
+
+    private TransactionSecurityRequest body;
+
+    /**
+     * @param chainId hexadecimal chain id, e.g. {@code "0x1"}
+     * @param from    sender address
+     * @param to      recipient / contract address
+     * @param data    call data, {@code "0x"} for a plain transfer
+     * @param value   native token amount
+     * @return TransactionSimulationRequest
+     */
+    public static TransactionSimulationRequest of(String chainId, String from, String to, String data, String value) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = buildBody(chainId, from, to, data, value);
+        return request;
+    }
+
+    /**
+     * @param chainId hexadecimal chain id, e.g. {@code "0x1"}
+     * @param from    sender address
+     * @param to      recipient / contract address
+     * @param data    call data, {@code "0x"} for a plain transfer
+     * @param value   native token amount
+     * @param authorization access token
+     * @return TransactionSimulationRequest
+     */
+    public static TransactionSimulationRequest of(String chainId, String from, String to, String data, String value, String authorization) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = buildBody(chainId, from, to, data, value);
+        request.authorization = authorization;
+        return request;
+    }
+
+    /**
+     * @param chainId hexadecimal chain id, e.g. {@code "0x1"}
+     * @param from    sender address
+     * @param to      recipient / contract address
+     * @param data    call data, {@code "0x"} for a plain transfer
+     * @param value   native token amount
+     * @param timeout timeout (MILLISECONDS)
+     * @return TransactionSimulationRequest
+     */
+    public static TransactionSimulationRequest of(String chainId, String from, String to, String data, String value, Integer timeout) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = buildBody(chainId, from, to, data, value);
+        request.timeout = timeout;
+        return request;
+    }
+
+    /**
+     * @param chainId hexadecimal chain id, e.g. {@code "0x1"}
+     * @param from    sender address
+     * @param to      recipient / contract address
+     * @param data    call data, {@code "0x"} for a plain transfer
+     * @param value   native token amount
+     * @param authorization access token
+     * @param timeout timeout (MILLISECONDS)
+     * @return TransactionSimulationRequest
+     */
+    public static TransactionSimulationRequest of(String chainId, String from, String to, String data, String value, String authorization, Integer timeout) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = buildBody(chainId, from, to, data, value);
+        request.authorization = authorization;
+        request.timeout = timeout;
+        return request;
+    }
+
+    /**
+     * Use this overload when the simulation needs the optional fields
+     * (gasLimit, gasPrice, maxFeePerGas, maxPriorityFeePerGas, nonce, accessList, url).
+     * Remember that {@code body.chainId} must be hexadecimal, e.g. {@code "0x1"}.
+     *
+     * @param body TransactionSecurityRequest
+     * @return TransactionSimulationRequest
+     */
+    public static TransactionSimulationRequest of(TransactionSecurityRequest body) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = body;
+        return request;
+    }
+
+    public static TransactionSimulationRequest of(TransactionSecurityRequest body, String authorization) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = body;
+        request.authorization = authorization;
+        return request;
+    }
+
+    public static TransactionSimulationRequest of(TransactionSecurityRequest body, Integer timeout) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = body;
+        request.timeout = timeout;
+        return request;
+    }
+
+    public static TransactionSimulationRequest of(TransactionSecurityRequest body, String authorization, Integer timeout) {
+        TransactionSimulationRequest request = new TransactionSimulationRequest();
+        request.body = body;
+        request.authorization = authorization;
+        request.timeout = timeout;
+        return request;
+    }
+
+    private static TransactionSecurityRequest buildBody(String chainId, String from, String to, String data, String value) {
+        return new TransactionSecurityRequest()
+                .chainId(chainId)
+                .from(from)
+                .to(to)
+                .data(data)
+                .value(value);
+    }
+
+    public TransactionSecurityRequest getBody() {
+        return body;
+    }
+}

--- a/src/main/java/io/gopluslabs/client/response/AddressScan.java
+++ b/src/main/java/io/gopluslabs/client/response/AddressScan.java
@@ -1,0 +1,14 @@
+package io.gopluslabs.client.response;
+
+import io.gopluslabs.client.model.ResponseWrapperOpenScanAddressResp;
+import net.kemitix.mon.TypeAlias;
+
+public class AddressScan extends TypeAlias<ResponseWrapperOpenScanAddressResp> {
+    protected AddressScan(final ResponseWrapperOpenScanAddressResp value) {
+        super(value);
+    }
+
+    public static AddressScan of(final ResponseWrapperOpenScanAddressResp response) {
+        return new AddressScan(response);
+    }
+}

--- a/src/main/java/io/gopluslabs/client/response/AddressScanResult.java
+++ b/src/main/java/io/gopluslabs/client/response/AddressScanResult.java
@@ -1,0 +1,14 @@
+package io.gopluslabs.client.response;
+
+import io.gopluslabs.client.model.ResponseWrapperGetScanResult;
+import net.kemitix.mon.TypeAlias;
+
+public class AddressScanResult extends TypeAlias<ResponseWrapperGetScanResult> {
+    protected AddressScanResult(final ResponseWrapperGetScanResult value) {
+        super(value);
+    }
+
+    public static AddressScanResult of(final ResponseWrapperGetScanResult response) {
+        return new AddressScanResult(response);
+    }
+}

--- a/src/main/java/io/gopluslabs/client/response/DustAttackDetection.java
+++ b/src/main/java/io/gopluslabs/client/response/DustAttackDetection.java
@@ -1,0 +1,14 @@
+package io.gopluslabs.client.response;
+
+import io.gopluslabs.client.model.ResponseWrapperDustAttackDetection;
+import net.kemitix.mon.TypeAlias;
+
+public class DustAttackDetection extends TypeAlias<ResponseWrapperDustAttackDetection> {
+    protected DustAttackDetection(final ResponseWrapperDustAttackDetection value) {
+        super(value);
+    }
+
+    public static DustAttackDetection of(final ResponseWrapperDustAttackDetection response) {
+        return new DustAttackDetection(response);
+    }
+}

--- a/src/main/java/io/gopluslabs/client/response/TransactionSimulation.java
+++ b/src/main/java/io/gopluslabs/client/response/TransactionSimulation.java
@@ -1,0 +1,14 @@
+package io.gopluslabs.client.response;
+
+import io.gopluslabs.client.model.ResponseWrapperTransactionSecurityResponse;
+import net.kemitix.mon.TypeAlias;
+
+public class TransactionSimulation extends TypeAlias<ResponseWrapperTransactionSecurityResponse> {
+    protected TransactionSimulation(final ResponseWrapperTransactionSecurityResponse value) {
+        super(value);
+    }
+
+    public static TransactionSimulation of(final ResponseWrapperTransactionSecurityResponse response) {
+        return new TransactionSimulation(response);
+    }
+}

--- a/src/test/java/GoPlusClientTest.java
+++ b/src/test/java/GoPlusClientTest.java
@@ -175,4 +175,43 @@ public class GoPlusClientTest {
         System.out.println(GoPlusClient.tokenSecurityForSui(request));
     }
 
+    @Test
+    public void dustAttackDetection() throws ApiException {
+        DustAttackDetectionRequest request = DustAttackDetectionRequest.of(
+                "0x408e41876cccdc0f92210600ef50372656052a38",
+                "0xd018e2b543a2669410537f96293590138cacedf3",
+                accessToken
+        );
+        System.out.println(GoPlusClient.dustAttackDetection(request));
+    }
+
+    @Test
+    public void addressScan() throws ApiException {
+        AddressScanRequest request = AddressScanRequest.of(
+                "0x408e41876cccdc0f92210600ef50372656052a38",
+                "1",
+                accessToken
+        );
+        System.out.println(GoPlusClient.addressScan(request));
+    }
+
+    @Test
+    public void addressScanResult() throws ApiException {
+        AddressScanResultRequest request = AddressScanResultRequest.of("", accessToken);
+        System.out.println(GoPlusClient.addressScanResult(request));
+    }
+
+    @Test
+    public void transactionSimulation() throws ApiException {
+        TransactionSimulationRequest request = TransactionSimulationRequest.of(
+                "0x1",
+                "0x408e41876cccdc0f92210600ef50372656052a38",
+                "0xd018e2b543a2669410537f96293590138cacedf3",
+                "0x",
+                "0",
+                accessToken
+        );
+        System.out.println(GoPlusClient.transactionSimulation(request));
+    }
+
 }


### PR DESCRIPTION
…lation in GoPlusClient

Commit 728f07f added three generated controllers that were not wired into the GoPlusClient facade, so callers had to use io.gopluslabs.client.api.* directly and build their own ApiClient.

Adds four facade methods following the existing request -> GoPlusClient -> response pattern:

- dustAttackDetection    POST /api/v1/dust_attack_detection
- addressScan            GET  /api/v1/address/scan/{chain_id}
- addressScanResult      GET  /api/v1/address/result
- transactionSimulation  POST /api/v1/transaction_simulation

addressScan and addressScanResult are the two halves of one asynchronous scan flow: the former returns a request_id that the latter polls with. They are kept as separate primitives so callers own the polling policy.

The outer request class is named TransactionSimulationRequest rather than TransactionSecurityRequest, which already exists in the model package and would clash with the wildcard imports in GoPlusClient.

transaction_simulation takes a hexadecimal chain id unlike every other API here, so that is called out in the javadoc of both the facade method and the request factories.